### PR TITLE
feat : Service-Overview Page with Service Card Components

### DIFF
--- a/skin/package-lock.json
+++ b/skin/package-lock.json
@@ -8,6 +8,9 @@
       "name": "skin",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/free-solid-svg-icons": "^5.15.4",
+        "@fortawesome/react-fontawesome": "^0.1.16",
         "@tanstack/react-query": "^4.29.7",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -2211,6 +2214,51 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.36",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
+      "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.x"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/skin/package.json
+++ b/skin/package.json
@@ -13,7 +13,10 @@
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.11.2",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+"@fortawesome/free-solid-svg-icons": "^5.15.4",
+"@fortawesome/react-fontawesome": "^0.1.16"
   },
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",

--- a/skin/src/App.js
+++ b/skin/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Home from './pages/Home';
+import ServiceOverview from './pages/ServiceOverview';
 
 // Create a client
 const queryClient = new QueryClient();
@@ -13,6 +14,7 @@ function App() {
         <div className="App">
           <Routes>
             <Route path="/" element={<Home />} />
+            <Route path="/service-overview" element={<ServiceOverview />} />
             {/* Add more routes here as needed */}
           </Routes>
         </div>

--- a/skin/src/components/ServiceCard.js
+++ b/skin/src/components/ServiceCard.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import '../styles/ServiceCard.css';
+
+function ServiceCard({ title, description, icon }) {
+  return (
+    <div className="service-card">
+      <div className="service-icon">{icon}</div>
+      <h2>{title}</h2>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+export default ServiceCard;
+

--- a/skin/src/pages/ServiceOverview.js
+++ b/skin/src/pages/ServiceOverview.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import Nav from '../components/Nav';
+import Footer from '../components/Footer';
+import ServiceCard from '../components/ServiceCard';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMicrochip, faCubes, faRocket, faCamera } from '@fortawesome/free-solid-svg-icons';
+import '../styles/ServiceOverview.css';
+
+function ServiceOverview() {
+  const services = [
+    {
+      title: 'VMs',
+      description: 'VM을 생성할 수 있습니다.',
+      icon: <FontAwesomeIcon icon={faMicrochip} />
+    },
+    {
+      title: 'K8s',
+      description: 'K8s 클러스터를 생성할 수 있습니다.',
+      icon: <FontAwesomeIcon icon={faCubes} />
+    },
+    {
+      title: 'IaC Deploy',
+      description: '지정한 환경을 안전하게 배포할 수 있습니다.',
+      icon: <FontAwesomeIcon icon={faRocket} />
+    },
+    {
+      title: 'Snapshot',
+      description: '반복적으로 생성하는 VM의 스냅샷을 찍어 양산해보세요.',
+      icon: <FontAwesomeIcon icon={faCamera} />
+    }
+  ];
+
+  return (
+    <div className="service-overview-page">
+      <Nav />
+      <main className="service-overview-content">
+        <h1>서비스 개요</h1>
+        <div className="service-grid">
+          {services.map((service, index) => (
+            <ServiceCard key={index} {...service} />
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+export default ServiceOverview;

--- a/skin/src/styles/ServiceCard.css
+++ b/skin/src/styles/ServiceCard.css
@@ -1,0 +1,27 @@
+.service-card {
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  padding: 1.5rem;
+  text-align: center;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.service-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.service-icon {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: #007bff;
+}
+
+.service-card h2 {
+  margin-bottom: 0.5rem;
+}
+
+.service-card p {
+  font-size: 0.9rem;
+  color: #6c757d;
+}

--- a/skin/src/styles/ServiceOverview.css
+++ b/skin/src/styles/ServiceOverview.css
@@ -1,0 +1,17 @@
+.service-overview-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.service-overview-content {
+  flex: 1;
+  padding: 2rem;
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}


### PR DESCRIPTION
# 서비스 개요 페이지 구현
#5 
## 변경 사항 요약
- 서비스 개요 페이지 (ServiceOverview) 컴포넌트 생성
- ServiceCard 컴포넌트 생성
- 관련 스타일 파일 추가
- App.js에 새로운 라우트 추가
- package.json에 FontAwesome 의존성 추가

## 폴더 구조
```
skin/
├── src/
│   ├── components/
│   │   ├── Footer.js
│   │   ├── Nav.js
│   │   └── ServiceCard.js
│   ├── pages/
│   │   ├── Home.js
│   │   └── ServiceOverview.js
│   ├── styles/
│   │   ├── Footer.css
│   │   ├── Home.css
│   │   ├── Nav.css
│   │   ├── ServiceCard.css
│   │   └── ServiceOverview.css
│   ├── utils/
│   │   └── apis.js
│   ├── App.js
│   └── index.js
├── .gitignore
├── docker-compose.yml
├── package.json
└── README.md
```

## 상세 변경 내용

### 1. 새로운 컴포넌트 생성

#### `skin/src/pages/ServiceOverview.js`
- 서비스 개요 페이지의 메인 컴포넌트 구현
- Nav와 Footer 컴포넌트 포함
- 4개의 서비스 카드 (VMs, K8s, IaC Deploy, Snapshot) 표시

#### `skin/src/components/ServiceCard.js`
- 개별 서비스 정보를 표시하는 재사용 가능한 카드 컴포넌트 구현

### 2. 스타일 파일 추가

#### `skin/src/styles/ServiceOverview.css`
- 서비스 개요 페이지의 레이아웃 및 스타일 정의

#### `skin/src/styles/ServiceCard.css`
- 서비스 카드의 스타일 정의

### 3. 라우팅 추가

#### `skin/src/App.js`
- ServiceOverview 컴포넌트에 대한 새로운 라우트 추가
  ```javascript
  <Route path="/service-overview" element={<ServiceOverview />} />
  ```

### 4. 의존성 추가

#### `skin/package.json`
- FontAwesome 라이브러리 의존성 추가:
  ```json
  "@fortawesome/fontawesome-svg-core": "^1.2.36",
  "@fortawesome/free-solid-svg-icons": "^5.15.4",
  "@fortawesome/react-fontawesome": "^0.1.16",
  ```

## 추가 작업 사항
- 반응형 디자인 개선
- 서비스 카드 클릭 시 상세 페이지로 이동하는 기능 구현
- 다국어 지원을 위한 텍스트 추출 및 번역 파일 준비